### PR TITLE
feat: update node pubkey to Seetee

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><rss xmlns:podcast="https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom" version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:anchor="https://anchor.fm/xmlns">
 	<channel>
 		<podcast:value type="lightning" method="keysend" suggested="0.00000005000">
-			<podcast:valueRecipient name="John" type="node" address="02a9cd2bca29dd7e29bdfdf485a8e78b8ccf9327517afa03a59be8f62a58792e1b" split="25"/>
+			<podcast:valueRecipient name="John" type="node" address="02aad0d3f1dafa0e120bf20258bff4b21c90c3d47557124e8035e4d9bd50f4f858" split="25"/>
 			<podcast:valueRecipient name="Gigi" type="node" address="02e12fea95f576a680ec1938b7ed98ef0855eadeced493566877d404e404bfbf52" split="25"/>
 			<podcast:valueRecipient name="Badders" type="node" address="021ce28b653fcb00d6e2e0aee00dba8cb1e20be90415bec44037f908cd869d9f88" split="25"/>
 			<podcast:valueRecipient name="Human Rights Foundation" type="node" address="03bbc38579cf51c6a098d1459371e1c99f26ddf330a76e683b7d485999a9ce48c7" split="25"/>
@@ -35,7 +35,7 @@
 		<item>
 			<title><![CDATA[#11 - Steve Barbour: The Solution Is to Plug in More ASICs]]></title>
 			<podcast:value type="lightning" method="keysend" suggested="0.00000005000">
-				<podcast:valueRecipient name="John (Host)" type="node" address="02a9cd2bca29dd7e29bdfdf485a8e78b8ccf9327517afa03a59be8f62a58792e1b" split="50"/>
+				<podcast:valueRecipient name="John (Host)" type="node" address="02aad0d3f1dafa0e120bf20258bff4b21c90c3d47557124e8035e4d9bd50f4f858" split="50"/>
 				<podcast:valueRecipient name="Human Rights Foundation (Donations)" type="node" address="03bbc38579cf51c6a098d1459371e1c99f26ddf330a76e683b7d485999a9ce48c7" split="50"/>
 			</podcast:value>
 			<description><![CDATA[<p>For this episode, our guest is <a href="https://twitter.com/SGBarbour" target="_blank">Steve Barbour</a>, founder and CEO of <a href="https://www.upstreamdata.ca/" target="_blank">Upstream Data</a>.</p>
@@ -97,7 +97,7 @@
 		<item>
 			<title><![CDATA[#10 - David Bailey: Celebrating Bitcoin Culture]]></title>
 			<podcast:value type="lightning" method="keysend" suggested="0.00000005000">
-				<podcast:valueRecipient name="John (Host)" type="node" address="02a9cd2bca29dd7e29bdfdf485a8e78b8ccf9327517afa03a59be8f62a58792e1b" split="50"/>
+				<podcast:valueRecipient name="John (Host)" type="node" address="02aad0d3f1dafa0e120bf20258bff4b21c90c3d47557124e8035e4d9bd50f4f858" split="50"/>
 				<podcast:valueRecipient name="Human Rights Foundation (Donations)" type="node" address="03bbc38579cf51c6a098d1459371e1c99f26ddf330a76e683b7d485999a9ce48c7" split="50"/>
 			</podcast:value>
 			<description><![CDATA[<p>This episode's guest is <a href="https://twitter.com/DavidFBailey" target="_blank">David Bailey</a>, CEO of BTC Inc., the company behind <a href="https://bitcoinmagazine.com/" target="_blank">Bitcoin Magazine</a>, <a href="https://b.tc/conference" target="_blank">The Bitcoin Conference</a>, and several other brands in the Bitcoin ecosystem.</p>
@@ -157,7 +157,7 @@
 		<item>
 			<title><![CDATA[#09 - Adam Curry: Can't Stop the Signal]]></title>
 			<podcast:value type="lightning" method="keysend" suggested="0.00000005000">
-				<podcast:valueRecipient name="John (Host)" type="node" address="02a9cd2bca29dd7e29bdfdf485a8e78b8ccf9327517afa03a59be8f62a58792e1b" split="50"/>
+				<podcast:valueRecipient name="John (Host)" type="node" address="02aad0d3f1dafa0e120bf20258bff4b21c90c3d47557124e8035e4d9bd50f4f858" split="50"/>
 				<podcast:valueRecipient name="Lightning Podcast Charity Fund" type="node" address="033868c219bdb51a33560d854d500fe7d3898a1ad9e05dd89d0007e11313588500" customKey="112111100" customValue="wal_SV5Uf4N3n5Xsc4" split="50"/>
 			</podcast:value>
 			<description><![CDATA[<p>Today's guest is legendary broadcaster turned podcaster <a href="https://twitter.com/adamcurry/" target="_blank">Adam Curry</a>.</p>
@@ -219,7 +219,7 @@
 			<title><![CDATA[#08 - Preston Pysh: A Once in a Millennium Opportunity]]></title>
 			<podcast:value type="lightning" method="keysend" suggested="0.00000005000">
 				<podcast:valueRecipient name="Human Rights Foundation (Donations)" type="node" address="03bbc38579cf51c6a098d1459371e1c99f26ddf330a76e683b7d485999a9ce48c7" split="50"/>
-				<podcast:valueRecipient name="John (Host)" type="node" address="02a9cd2bca29dd7e29bdfdf485a8e78b8ccf9327517afa03a59be8f62a58792e1b" split="50"/>
+				<podcast:valueRecipient name="John (Host)" type="node" address="02aad0d3f1dafa0e120bf20258bff4b21c90c3d47557124e8035e4d9bd50f4f858" split="50"/>
 			</podcast:value>
 			<description><![CDATA[<p>Today's guest is <a href="https://twitter.com/PrestonPysh/" target="_blank">Preston Pysh</a>, co-creator of <a href="https://www.theinvestorspodcast.com/" target="_blank"><em>The Investor's Podcast Network</em></a>, one of the top global podcast brands for financial education.</p>
 <p>While his podcast network covers the goings-on in finance, investing, and economics broadly, Preston has more recently focused exclusively on Bitcoin. He is now hosting a weekly discussion with the top entrepreneurs, authors, and investors in this rapidly growing ecosystem.</p>
@@ -277,7 +277,7 @@
 			<title><![CDATA[#07 - Dhruv Bansal: Bitcoin-Native Financial Services w/ Unchained Capital]]></title>
 			<podcast:value type="lightning" method="keysend" suggested="0.00000005000">
 				<podcast:valueRecipient name="Human Rights Foundation (Donations)" type="node" address="03bbc38579cf51c6a098d1459371e1c99f26ddf330a76e683b7d485999a9ce48c7" split="50"/>
-				<podcast:valueRecipient name="John (Host)" type="node" address="02a9cd2bca29dd7e29bdfdf485a8e78b8ccf9327517afa03a59be8f62a58792e1b" split="50"/>
+				<podcast:valueRecipient name="John (Host)" type="node" address="02aad0d3f1dafa0e120bf20258bff4b21c90c3d47557124e8035e4d9bd50f4f858" split="50"/>
 			</podcast:value>
 			<description><![CDATA[<p>Today's guest is <a href="https://twitter.com/dhruvbansal" target="_blank">Dhruv Bansal</a>, co-founder and CSO at <a href="https://unchained.com/" target="_blank">Unchained Capital</a>. Unchained is a bitcoin-native financial services company that builds products to help individuals and organizations to better custody and hodl their bitcoin.</p>
 <p>Crucial to this is their focus on collaborative custody using multisig, which allows them to offer robust key management solutions, transparent bitcoin collateralized loans, retirement and inheritance planning, and likely much more in the future.</p>
@@ -337,7 +337,7 @@
 			<title><![CDATA[#06 - Whit Gibbs: Now Everyone Can Mine Bitcoin]]></title>
 			<podcast:value type="lightning" method="keysend" suggested="0.00000005000">
 				<podcast:valueRecipient name="Human Rights Foundation (Donations)" type="node" address="03bbc38579cf51c6a098d1459371e1c99f26ddf330a76e683b7d485999a9ce48c7" split="50"/>
-				<podcast:valueRecipient name="John (Host)" type="node" address="02a9cd2bca29dd7e29bdfdf485a8e78b8ccf9327517afa03a59be8f62a58792e1b" split="50"/>
+				<podcast:valueRecipient name="John (Host)" type="node" address="02aad0d3f1dafa0e120bf20258bff4b21c90c3d47557124e8035e4d9bd50f4f858" split="50"/>
 			</podcast:value>
 			<description><![CDATA[<p>Today's guest is <a href="https://twitter.com/BitcoinBroski" target="_blank">Whit Gibbs</a>, co-founder, and CEO of <a href="https://compassmining.io/" target="_blank">Compass Mining</a>.</p>
 <p>According to their website, "Compass is a Bitcoin-first company, on a mission to support the decentralized growth of hashrate and strengthen network security, by helping more people learn, explore and mine Bitcoin."</p>
@@ -395,7 +395,7 @@
 			<title><![CDATA[#05 - Roy Sheinfeld: The Interface of the Peer to Peer Lightning Economy w/ Breez]]></title>
 			<podcast:value type="lightning" method="keysend" suggested="0.00000005000">
 				<podcast:valueRecipient name="Human Rights Foundation (Donations)" type="node" address="03bbc38579cf51c6a098d1459371e1c99f26ddf330a76e683b7d485999a9ce48c7" split="50"/>
-				<podcast:valueRecipient name="John (Host)" type="node" address="02a9cd2bca29dd7e29bdfdf485a8e78b8ccf9327517afa03a59be8f62a58792e1b" split="50"/>
+				<podcast:valueRecipient name="John (Host)" type="node" address="02aad0d3f1dafa0e120bf20258bff4b21c90c3d47557124e8035e4d9bd50f4f858" split="50"/>
 			</podcast:value>
 			<description><![CDATA[<p>Today's guest on Closing the Loop is <a href="https://medium.com/@kingonly" target="_blank">Roy Sheinfeld</a>. Roy is the CEO and Co-Founder of <a href="https://breez.technology/" target="_blank">Breez</a>, a mobile app that aspires to be 'The interface of the peer to peer lightning economy.'</p>
 <p>Roy and his team have taken a nascent, though still largely intimidating technology and abstracted away much of the complexity so that the average user can begin to interact with it and leverage the tremendous value which the lightning network increasingly represents.</p>
@@ -575,7 +575,7 @@
 		<item>
 			<title><![CDATA[#02 - Paul Itoi: Stakwork, Sphinx Chat, and the Bitcoin Lightning Economy]]></title>
 			<podcast:value type="lightning" method="keysend" suggested="0.00000005000">
-				<podcast:valueRecipient name="John (Host)" type="node" address="02a9cd2bca29dd7e29bdfdf485a8e78b8ccf9327517afa03a59be8f62a58792e1b" split="50"/>
+				<podcast:valueRecipient name="John (Host)" type="node" address="02aad0d3f1dafa0e120bf20258bff4b21c90c3d47557124e8035e4d9bd50f4f858" split="50"/>
 				<podcast:valueRecipient name="Paul Itoi (Guest)" type="node" address="03a9a8d953fe747d0dd94dd3c567ddc58451101e987e2d2bf7a4d1e10a2c89ff38" split="50"/>
 			</podcast:value>
 			<description><![CDATA[<p><a href="https://twitter.com/paulitoi" target="_blank">Paul Itoi</a> is the founder and CEO of <a href="https://stakwork.com/" target="_blank">Stakwork</a> and has been a tech entrepreneur since the mid-nineties. In his spare time, Paul is also one of the driving forces behind the open-source, lightning-powered chat-app, called <a href="https://sphinx.chat/" target="_blank">Sphinx</a>. As Paul puts it, Stakwork pays the bills, but Sphinx just needed to exist, so they built it.</p>
@@ -629,7 +629,7 @@
 		<item>
 			<title><![CDATA[#01 - Gigi: Introduction to Closing the Loop]]></title>
 			<podcast:value type="lightning" method="keysend" suggested="0.00000005000">
-				<podcast:valueRecipient name="John (Host)" type="node" address="02a9cd2bca29dd7e29bdfdf485a8e78b8ccf9327517afa03a59be8f62a58792e1b" split="33"/>
+				<podcast:valueRecipient name="John (Host)" type="node" address="02aad0d3f1dafa0e120bf20258bff4b21c90c3d47557124e8035e4d9bd50f4f858" split="33"/>
 				<podcast:valueRecipient name="Gigi (Guest)" type="node" address="02e12fea95f576a680ec1938b7ed98ef0855eadeced493566877d404e404bfbf52" split="33"/>
 				<podcast:valueRecipient name="Badders (Audio Engineer)" type="node" address="021ce28b653fcb00d6e2e0aee00dba8cb1e20be90415bec44037f908cd869d9f88" split="33"/>
 			</podcast:value>


### PR DESCRIPTION
As discussed, this updates John's node ID to the Seetee node ID so that we can parse boosts and boostagrams.